### PR TITLE
Correct secret type for Docker config

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ jobs:
       uses: azure/k8s-create-secret@v2
       with:
         namespace: 'myapp'
-        secret-type: 'docker-registry'
+        secret-type: 'kubernetes.io/dockerconfigjson'
         secret-name: 'contoso-cr'
         string-data: ${{ secrets.SECRET_STRING_DATA}}
       id: create-secret


### PR DESCRIPTION
The suggested secret type does not work as a pull secret. Change to a type documented in the k8s docs: https://kubernetes.io/docs/concepts/configuration/secret/#docker-config-secrets