### PR TITLE
update minikube action to get ubuntu 22.04 support

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,7 +12,7 @@ jobs:
       steps:
          - id: setup-minikube
            name: Setup Minikube
-           uses: medyagh/setup-minikube@ab221dee176f8eabd8deddf849b5bf1d6244a6e8
+           uses: medyagh/setup-minikube@ab221de
            with:
               minikube-version: 'v1.24.0'
               kubernetes-version: 'v1.17.8'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,7 +12,7 @@ jobs:
       steps:
          - id: setup-minikube
            name: Setup Minikube
-           uses: manusa/actions-setup-minikube@v2.4.2
+           uses: manusa/actions-setup-minikube@v2.7.2
            with:
               minikube version: 'v1.24.0'
               kubernetes version: 'v1.17.8'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,11 +12,12 @@ jobs:
       steps:
          - id: setup-minikube
            name: Setup Minikube
-           uses: medyagh/setup-minikube@ab221dee176f8eabd8deddf849b5bf1d6244a6e8
+           uses: medyagh/setup-minikube@latest
            with:
-              minikube-version: 'v1.24.0'
-              kubernetes-version: 'v1.17.8'
+              minikube-version: 1.24.0
+              kubernetes-version: 1.22.3
               driver: 'none'
+           timeout-minutes: 3
          - uses: actions/checkout@v1
          - id: action-npm-build
            name: npm install and build

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -63,7 +63,7 @@ jobs:
               minikube-version: 1.24.0
               kubernetes-version: 1.22.3
               driver: 'none'
-           timeout-minutes: 3 
+           timeout-minutes: 3
          - uses: actions/checkout@v1
          - id: action-npm-build
            name: npm install and build

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,6 +10,8 @@ jobs:
          KUBECONFIG: /home/runner/.kube/config
          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
       steps:
+         - name: Install conntrack
+           run: sudo apt-get install -y conntrack
          - id: setup-minikube
            name: Setup Minikube
            uses: medyagh/setup-minikube@latest

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,7 +12,7 @@ jobs:
       steps:
          - id: setup-minikube
            name: Setup Minikube
-           uses: medyagh/setup-minikube@ab221de
+           uses: medyagh/setup-minikube@ab221dee176f8eabd8deddf849b5bf1d6244a6e8
            with:
               minikube-version: 'v1.24.0'
               kubernetes-version: 'v1.17.8'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -54,13 +54,16 @@ jobs:
          KUBECONFIG: /home/runner/.kube/config
          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
       steps:
+         - name: Install conntrack
+           run: sudo apt-get install -y conntrack
          - id: setup-minikube
            name: Setup Minikube
-           uses: manusa/actions-setup-minikube@v2.4.2
+           uses: medyagh/setup-minikube@latest
            with:
-              minikube version: 'v1.24.0'
-              kubernetes version: 'v1.17.8'
+              minikube-version: 1.24.0
+              kubernetes-version: 1.22.3
               driver: 'none'
+           timeout-minutes: 3 
          - uses: actions/checkout@v1
          - id: action-npm-build
            name: npm install and build

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,10 +12,10 @@ jobs:
       steps:
          - id: setup-minikube
            name: Setup Minikube
-           uses: manusa/actions-setup-minikube@v2.7.2
+           uses: medyagh/setup-minikube@ab221dee176f8eabd8deddf849b5bf1d6244a6e8
            with:
-              minikube version: 'v1.24.0'
-              kubernetes version: 'v1.17.8'
+              minikube-version: 'v1.24.0'
+              kubernetes-version: 'v1.17.8'
               driver: 'none'
          - uses: actions/checkout@v1
          - id: action-npm-build


### PR DESCRIPTION
integration tests are currently broken due to unsupported ubuntu version on the runners since they upped the `latest` tag

pin action to SHA as well