### PR TITLE
Bug fix for Invalid Secret type after using k8s-create-secret action

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
    "requires": true,
    "packages": {
       "": {
+         "name": "k8s-create-secret-action",
          "version": "5.0.0",
          "license": "MIT",
          "dependencies": {

--- a/src/run.ts
+++ b/src/run.ts
@@ -57,7 +57,29 @@ export async function buildSecret(
    namespace: string
 ): Promise<V1Secret> {
    // The secret type for the new secret
-   const secretType: string = core.getInput('secret-type')
+   const inputSecretType = core.getInput('secret-type')?.toLowerCase()
+
+let secretType: string
+switch (inputSecretType) {
+   case 'dockerconfigjson':
+      secretType = 'kubernetes.io/dockerconfigjson'
+      break
+   case 'tls':
+      secretType = 'kubernetes.io/tls'
+      break
+   case 'basic-auth':
+      secretType = 'kubernetes.io/basic-auth'
+      break
+   case 'ssh-auth':
+      secretType = 'kubernetes.io/ssh-auth'
+      break
+   case 'bootstrap-token':
+      secretType = 'bootstrap.kubernetes.io/token'
+      break
+   case 'generic':
+   default:
+      secretType = 'Opaque'
+}
 
    const metaData: V1ObjectMeta = {
       name: secretName,


### PR DESCRIPTION
This change introduces a switch statement to map user-provided secret type aliases (inputSecretType) to their corresponding Kubernetes secret types. 