### PR TITLE
fix for generic secret types

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -146,13 +146,16 @@ export async function buildSecret(
 
    return secret
 }
-const K8S_SECRET_TYPE_OPAQUE = 'Opaque'  // Kubernetes secret type for generic secrets
+const K8S_SECRET_TYPE_OPAQUE = 'Opaque' // Kubernetes secret type for generic secrets
 const SECRET_TYPE_GENERIC = 'generic'
 const SECRET_TYPE_OPAQUE = 'opaque'
 
 function mapSecretType(inputType: string): string {
    const normalizedType = inputType.toLowerCase().trim()
-   if (normalizedType === SECRET_TYPE_GENERIC || normalizedType === SECRET_TYPE_OPAQUE) {
+   if (
+      normalizedType === SECRET_TYPE_GENERIC ||
+      normalizedType === SECRET_TYPE_OPAQUE
+   ) {
       return K8S_SECRET_TYPE_OPAQUE
    }
    return inputType

--- a/src/run.ts
+++ b/src/run.ts
@@ -54,7 +54,7 @@ export function buildContainerRegistryDockerConfigJSON(
 
 export async function buildSecret(
    secretName: string,
-   namespace: string
+   namespace: string,
    secretType: string
 ): Promise<V1Secret> {
    const metaData: V1ObjectMeta = {
@@ -176,7 +176,6 @@ export async function run() {
 
    // Normalize and map the raw input to a valid Kubernetes secret type
    const secretType = mapSecretType(rawSecretType)
-
 
    // The namespace in which to place the secret
    const namespace: string = core.getInput('namespace') || 'default'

--- a/src/run.ts
+++ b/src/run.ts
@@ -146,10 +146,15 @@ export async function buildSecret(
 
    return secret
 }
+const K8S_SECRET_TYPE_OPAQUE = 'Opaque'  // Kubernetes secret type for generic secrets
+const SECRET_TYPE_GENERIC = 'generic'
+const SECRET_TYPE_OPAQUE = 'opaque'
+
 function mapSecretType(inputType: string): string {
-   const t = inputType.toLowerCase().trim()
-   const K8S_SECRET_TYPE_OPAQUE = 'Opaque'
-   if (t === 'generic' || t === 'opaque') return K8S_SECRET_TYPE_OPAQUE
+   const normalizedType = inputType.toLowerCase().trim()
+   if (normalizedType === SECRET_TYPE_GENERIC || normalizedType === SECRET_TYPE_OPAQUE) {
+      return K8S_SECRET_TYPE_OPAQUE
+   }
    return inputType
 }
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -54,7 +54,7 @@ export function buildContainerRegistryDockerConfigJSON(
 
 export async function buildSecret(
    secretName: string,
-   namespace: string,
+   namespace: string
    secretType: string
 ): Promise<V1Secret> {
    const metaData: V1ObjectMeta = {
@@ -171,11 +171,15 @@ export async function run() {
    // The name of the new secret
    const secretName: string = core.getInput('secret-name', {required: true})
 
+   // Get the raw input from the workflow YAML (may include casing or whitespace issues)
+   const rawSecretType = core.getInput('secret-type')
+
+   // Normalize and map the raw input to a valid Kubernetes secret type
+   const secretType = mapSecretType(rawSecretType)
+
+
    // The namespace in which to place the secret
    const namespace: string = core.getInput('namespace') || 'default'
-
-   // The secret type for the new secret
-   const secretType: string = mapSecretType(core.getInput('secret-type'))
 
    // Delete if exists
    let deleteSecretResponse

--- a/src/run.ts
+++ b/src/run.ts
@@ -148,7 +148,8 @@ export async function buildSecret(
 }
 function mapSecretType(inputType: string): string {
    const t = inputType.toLowerCase().trim()
-   if (t === 'generic' || t === 'opaque') return 'Opaque'
+   const K8S_SECRET_TYPE_OPAQUE = 'Opaque'
+   if (t === 'generic' || t === 'opaque') return K8S_SECRET_TYPE_OPAQUE
    return inputType
 }
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -57,7 +57,7 @@ export async function buildSecret(
    namespace: string
 ): Promise<V1Secret> {
    // The secret type for the new secret
-   const secretType: string = core.getInput('secret-type')
+   const secretType: string = mapSecretType(core.getInput('secret-type'))
 
    const metaData: V1ObjectMeta = {
       name: secretName,
@@ -145,6 +145,11 @@ export async function buildSecret(
    }
 
    return secret
+}
+function mapSecretType(inputType: string): string {
+   const t = inputType.toLowerCase().trim()
+   if (t === 'generic' || t === 'opaque') return 'Opaque'
+   return inputType
 }
 
 export async function run() {

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -45,19 +45,19 @@ describe('buildSecret', () => {
       process.env['INPUT_SECRET-TYPE'] = 'generic'
    })
    it('should use api v1', async () => {
-      let secret = await buildSecret('test-secret', 'test-namespace')
+      let secret = await buildSecret('test-secret', 'test-namespace', 'generic')
       expect(secret.apiVersion).toBe('v1')
    })
 
    it('should have namespace in metadata field', async () => {
       const testNamespace = 'test-namespace'
-      let secret = await buildSecret('test-secret', testNamespace)
+      let secret = await buildSecret('test-secret', testNamespace, 'generic')
       expect(secret.metadata.namespace).toBe(testNamespace)
    })
    it('should have name in metadata field', async () => {
       const testNamespace = 'test-namespace'
       const testName = 'test-secret'
-      let secret = await buildSecret(testName, testNamespace)
+      let secret = await buildSecret(testName, testNamespace, 'generic')
       expect(secret.metadata.name).toBe(testName)
    })
 })


### PR DESCRIPTION
This change introduces a minimal mapping function that converts the user input "generic" (and "opaque") to the correct Kubernetes type "Opaque" before creating the secret. All other secret types are passed through unchanged, so existing workflows using other types are unaffected. This PR address issue #100 