### PR TITLE
feat: added logic for TLS secret type handling

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,11 +31,11 @@ inputs:
       description: 'JSON object with the serialized form of the secret data in a base64 encoded string ex: {"key1":"[base64 encoded data]"}'
       required: false
    tls-cert:
-    description: 'Base64 encoded TLS certificate (PEM format)'
-    required: false
+      description: 'Base64 encoded TLS certificate (PEM format)'
+      required: false
    tls-key:
-    description: 'Base64 encoded TLS private key (PEM format)'
-    required: false 
+      description: 'Base64 encoded TLS private key (PEM format)'
+      required: false
 outputs:
    secret-name:
       description: 'Secret name'

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'Create secret in Kubernetes cluster'
-description: 'Create a generic secret or docker-registry secret in a Kubernetes such as Azure Kubernetes Service (AKS) clusters'
+description: 'Create a generic secret, docker-registry secret, or TLS secret in a Kubernetes such as Azure Kubernetes Service (AKS) clusters'
 inputs:
    # Please ensure you have used either azure/k8s-actions/aks-set-context or azure/k8s-actions/k8s-set-context in the workflow before this action
    namespace:
@@ -30,6 +30,12 @@ inputs:
    data:
       description: 'JSON object with the serialized form of the secret data in a base64 encoded string ex: {"key1":"[base64 encoded data]"}'
       required: false
+   tls-cert:
+    description: 'Base64 encoded TLS certificate (PEM format)'
+    required: false
+   tls-key:
+    description: 'Base64 encoded TLS private key (PEM format)'
+    required: false 
 outputs:
    secret-name:
       description: 'Secret name'

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
    "requires": true,
    "packages": {
       "": {
+         "name": "k8s-create-secret-action",
          "version": "5.0.0",
          "license": "MIT",
          "dependencies": {
@@ -3290,7 +3291,6 @@
          "version": "1.3.0",
          "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-1.3.0.tgz",
          "integrity": "sha512-IE0yrIpOT97YS5fg2QpzmPzm8Wmcdf4ueWMn+FiJSI3jgTTQT1u+LUhoYpdfhdHAVxdrNsaBg2C0UXSnOgMoCQ==",
-         "license": "Apache-2.0",
          "dependencies": {
             "@types/js-yaml": "^4.0.1",
             "@types/node": "^22.0.0",

--- a/src/run.ts
+++ b/src/run.ts
@@ -117,6 +117,18 @@ export async function buildSecret(
          data: data
       }
    }
+    if (secretType === 'kubernetes.io/tls') {
+       const tlsCert = core.getInput('tls-cert')
+       const tlsKey  = core.getInput('tls-key')
+       const data    = buildTlsSecretData(tlsCert, tlsKey)
+       return {
+         apiVersion: 'v1',
+         kind: 'Secret',
+         metadata: metaData,
+         type: secretType,
+         data: data
+      }
+   }
 
    // The serialized form of the secret data is a base64 encoded string
    let data: {[key: string]: string} = {}
@@ -155,7 +167,16 @@ function mapSecretType(inputType: string): string {
    ) {
       return K8S_SECRET_TYPE_OPAQUE
    }
+    if (normalizedType === 'tls' || normalizedType === 'kubernetes.io/tls') {
+      return 'kubernetes.io/tls'
+   }
    return inputType
+}
+function buildTlsSecretData(cert: string, key: string) {
+  if (!cert || !key) {
+    throw new Error('Both tls-cert and tls-key must be provided for type kubernetes.io/tls');
+  }
+  return { 'tls.crt': cert, 'tls.key': key };
 }
 
 export async function run() {

--- a/src/run.ts
+++ b/src/run.ts
@@ -117,11 +117,11 @@ export async function buildSecret(
          data: data
       }
    }
-    if (secretType === 'kubernetes.io/tls') {
-       const tlsCert = core.getInput('tls-cert')
-       const tlsKey  = core.getInput('tls-key')
-       const data    = buildTlsSecretData(tlsCert, tlsKey)
-       return {
+   if (secretType === 'kubernetes.io/tls') {
+      const tlsCert = core.getInput('tls-cert')
+      const tlsKey = core.getInput('tls-key')
+      const data = buildTlsSecretData(tlsCert, tlsKey)
+      return {
          apiVersion: 'v1',
          kind: 'Secret',
          metadata: metaData,
@@ -167,16 +167,18 @@ function mapSecretType(inputType: string): string {
    ) {
       return K8S_SECRET_TYPE_OPAQUE
    }
-    if (normalizedType === 'tls' || normalizedType === 'kubernetes.io/tls') {
+   if (normalizedType === 'tls' || normalizedType === 'kubernetes.io/tls') {
       return 'kubernetes.io/tls'
    }
    return inputType
 }
 function buildTlsSecretData(cert: string, key: string) {
-  if (!cert || !key) {
-    throw new Error('Both tls-cert and tls-key must be provided for type kubernetes.io/tls');
-  }
-  return { 'tls.crt': cert, 'tls.key': key };
+   if (!cert || !key) {
+      throw new Error(
+         'Both tls-cert and tls-key must be provided for type kubernetes.io/tls'
+      )
+   }
+   return {'tls.crt': cert, 'tls.key': key}
 }
 
 export async function run() {

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -60,6 +60,19 @@ describe('buildSecret', () => {
       let secret = await buildSecret(testName, testNamespace, 'generic')
       expect(secret.metadata.name).toBe(testName)
    })
+   it('should build TLS secret with cert and key', async () => {
+   process.env['INPUT_SECRET-TYPE'] = 'kubernetes.io/tls'
+   process.env['INPUT_TLS-CERT'] = 'dummyBase64Cert'
+   process.env['INPUT_TLS-KEY'] = 'dummyBase64Key'
+   const secret = await buildSecret('tls-secret', 'tls-namespace', 'kubernetes.io/tls')
+   expect(secret.apiVersion).toBe('v1')
+   expect(secret.type).toBe('kubernetes.io/tls')
+   expect(secret.metadata.name).toBe('tls-secret')
+   expect(secret.metadata.namespace).toBe('tls-namespace')
+   expect(secret.data['tls.crt']).toBe('dummyBase64Cert')
+   expect(secret.data['tls.key']).toBe('dummyBase64Key')
+})
+
 })
 
 describe('buildContainerRegistryDockerConfigJSON', () => {
@@ -103,7 +116,6 @@ describe('buildContainerRegistryDockerConfigJSON', () => {
             }
          }
       }
-
       const dockerConfigJson = buildContainerRegistryDockerConfigJSON(
          testContainerRegistryUrl,
          testContainerRegistryUserName,
@@ -112,4 +124,5 @@ describe('buildContainerRegistryDockerConfigJSON', () => {
       )
       expect(dockerConfigJson).toEqual(exptectedDockerConfigJsonNoEmail)
    })
+   
 })

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -61,18 +61,21 @@ describe('buildSecret', () => {
       expect(secret.metadata.name).toBe(testName)
    })
    it('should build TLS secret with cert and key', async () => {
-   process.env['INPUT_SECRET-TYPE'] = 'kubernetes.io/tls'
-   process.env['INPUT_TLS-CERT'] = 'dummyBase64Cert'
-   process.env['INPUT_TLS-KEY'] = 'dummyBase64Key'
-   const secret = await buildSecret('tls-secret', 'tls-namespace', 'kubernetes.io/tls')
-   expect(secret.apiVersion).toBe('v1')
-   expect(secret.type).toBe('kubernetes.io/tls')
-   expect(secret.metadata.name).toBe('tls-secret')
-   expect(secret.metadata.namespace).toBe('tls-namespace')
-   expect(secret.data['tls.crt']).toBe('dummyBase64Cert')
-   expect(secret.data['tls.key']).toBe('dummyBase64Key')
-})
-
+      process.env['INPUT_SECRET-TYPE'] = 'kubernetes.io/tls'
+      process.env['INPUT_TLS-CERT'] = 'dummyBase64Cert'
+      process.env['INPUT_TLS-KEY'] = 'dummyBase64Key'
+      const secret = await buildSecret(
+         'tls-secret',
+         'tls-namespace',
+         'kubernetes.io/tls'
+      )
+      expect(secret.apiVersion).toBe('v1')
+      expect(secret.type).toBe('kubernetes.io/tls')
+      expect(secret.metadata.name).toBe('tls-secret')
+      expect(secret.metadata.namespace).toBe('tls-namespace')
+      expect(secret.data['tls.crt']).toBe('dummyBase64Cert')
+      expect(secret.data['tls.key']).toBe('dummyBase64Key')
+   })
 })
 
 describe('buildContainerRegistryDockerConfigJSON', () => {
@@ -124,5 +127,4 @@ describe('buildContainerRegistryDockerConfigJSON', () => {
       )
       expect(dockerConfigJson).toEqual(exptectedDockerConfigJsonNoEmail)
    })
-   
 })


### PR DESCRIPTION
This PR adds support for creating Kubernetes TLS secrets via the GitHub Action. Users can now provide Base64-encoded TLS certificate and key inputs, and the action will generate a kubernetes.io/tls secret accordingly. This PR addresses #92 