### PR TITLE
feat: added logic for TLS secrert type handling

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'Create secret in Kubernetes cluster'
-description: 'Create a generic secret or docker-registry secret in a Kubernetes such as Azure Kubernetes Service (AKS) clusters'
+description: 'Create a generic secret, docker-registry secret, or TLS secret in a Kubernetes such as Azure Kubernetes Service (AKS) clusters'
 inputs:
    # Please ensure you have used either azure/k8s-actions/aks-set-context or azure/k8s-actions/k8s-set-context in the workflow before this action
    namespace:
@@ -29,6 +29,12 @@ inputs:
       required: false
    data:
       description: 'JSON object with the serialized form of the secret data in a base64 encoded string ex: {"key1":"[base64 encoded data]"}'
+      required: false
+   tls-cert:
+      description: 'Base64 encoded TLS certificate (PEM format)'
+      required: false
+   tls-key:
+      description: 'Base64 encoded TLS private key (PEM format)'
       required: false
 outputs:
    secret-name:

--- a/src/run.ts
+++ b/src/run.ts
@@ -117,6 +117,18 @@ export async function buildSecret(
          data: data
       }
    }
+   if (secretType === 'kubernetes.io/tls') {
+      const tlsCert = core.getInput('tls-cert')
+      const tlsKey = core.getInput('tls-key')
+      const data = buildTlsSecretData(tlsCert, tlsKey)
+      return {
+         apiVersion: 'v1',
+         kind: 'Secret',
+         metadata: metaData,
+         type: secretType,
+         data: data
+      }
+   }
 
    // The serialized form of the secret data is a base64 encoded string
    let data: {[key: string]: string} = {}
@@ -155,7 +167,18 @@ function mapSecretType(inputType: string): string {
    ) {
       return K8S_SECRET_TYPE_OPAQUE
    }
+   if (normalizedType === 'tls' || normalizedType === 'kubernetes.io/tls') {
+      return 'kubernetes.io/tls'
+   }
    return inputType
+}
+function buildTlsSecretData(cert: string, key: string) {
+   if (!cert || !key) {
+      throw new Error(
+         'Both tls-cert and tls-key must be provided for type kubernetes.io/tls'
+      )
+   }
+   return {'tls.crt': cert, 'tls.key': key}
 }
 
 export async function run() {

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -60,6 +60,22 @@ describe('buildSecret', () => {
       let secret = await buildSecret(testName, testNamespace, 'generic')
       expect(secret.metadata.name).toBe(testName)
    })
+   it('should build TLS secret with cert and key', async () => {
+      process.env['INPUT_SECRET-TYPE'] = 'kubernetes.io/tls'
+      process.env['INPUT_TLS-CERT'] = 'dummyBase64Cert'
+      process.env['INPUT_TLS-KEY'] = 'dummyBase64Key'
+      const secret = await buildSecret(
+         'tls-secret',
+         'tls-namespace',
+         'kubernetes.io/tls'
+      )
+      expect(secret.apiVersion).toBe('v1')
+      expect(secret.type).toBe('kubernetes.io/tls')
+      expect(secret.metadata.name).toBe('tls-secret')
+      expect(secret.metadata.namespace).toBe('tls-namespace')
+      expect(secret.data['tls.crt']).toBe('dummyBase64Cert')
+      expect(secret.data['tls.key']).toBe('dummyBase64Key')
+   })
 })
 
 describe('buildContainerRegistryDockerConfigJSON', () => {
@@ -103,7 +119,6 @@ describe('buildContainerRegistryDockerConfigJSON', () => {
             }
          }
       }
-
       const dockerConfigJson = buildContainerRegistryDockerConfigJSON(
          testContainerRegistryUrl,
          testContainerRegistryUserName,


### PR DESCRIPTION
This PR adds support for creating Kubernetes TLS secrets via the GitHub Action. Users can now provide Base64-encoded TLS certificate and key inputs, and the action will generate a kubernetes.io/tls secret accordingly. This PR addresses #92 