### PR TITLE
Release v6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [6.0.0] - 2026-04-20
+
+### Added
+
+- [#172](https://github.com/Azure/k8s-create-secret/pull/172) Added logic for TLS secret type handling
+- [#166](https://github.com/Azure/k8s-create-secret/pull/166) Add husky pre-commit hook
+
+### Changed
+
+- [#238](https://github.com/Azure/k8s-create-secret/pull/238) Migrate project to ESM with esbuild and vitest
+- [#229](https://github.com/Azure/k8s-create-secret/pull/229) Update Node.js runtime from node20 to node24
+- [#215](https://github.com/Azure/k8s-create-secret/pull/215) Use docker driver in minikube setup
+- [#180](https://github.com/Azure/k8s-create-secret/pull/180) Update CODEOWNERS
+- Bump npm dependencies: `@types/node`, `prettier`, `undici`, `@actions/http-client`, `handlebars`, `picomatch`, `minimatch`, `js-yaml`, `glob`, `tar-fs`, `form-data`, `jest` (#174, #175, #178, #179, #194, #201, #203, #205, #206, #209, #213, #223, #226, #231, #235, #236)
+- Bump GitHub Actions: `github/codeql-action`, `actions/setup-node`, and other grouped action updates in `.github/workflows` (#163, #164, #169, #170, #182, #183, #184, #185, #186, #187, #188, #189, #190, #191, #197, #198, #199, #200, #204, #207, #208, #210, #211, #212, #214, #216, #217, #218, #219, #221, #224, #225, #227, #228, #233, #237)
+
+### Fixed
+
+- [#168](https://github.com/Azure/k8s-create-secret/pull/168) Fix for generic secret types
+
 ## [5.0.1] - 2024-09-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jobs:
       runs-on: ubuntu-latest
       steps:
          - name: Set imagePullSecret
-           uses: azure/k8s-create-secret@v4
+           uses: azure/k8s-create-secret@v6
            with:
               namespace: 'myapp'
               secret-name: 'contoso-cr'
@@ -41,7 +41,7 @@ jobs:
    example-job:
       runs-on: ubuntu-latest
       steps:
-         - uses: azure/k8s-create-secret@v2
+         - uses: azure/k8s-create-secret@v6
            with:
               namespace: 'default'
               secret-type: 'generic'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
    "name": "k8s-create-secret-action",
-   "version": "5.0.0",
+   "version": "6.0.0",
    "lockfileVersion": 3,
    "requires": true,
    "packages": {
       "": {
          "name": "k8s-create-secret-action",
-         "version": "5.0.0",
+         "version": "6.0.0",
          "license": "MIT",
          "dependencies": {
             "@actions/core": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "k8s-create-secret-action",
-   "version": "5.0.0",
+   "version": "6.0.0",
    "private": true,
    "type": "module",
    "main": "lib/index.js",


### PR DESCRIPTION
## Summary

Release PR for **v6.0.0** — major version bump covering all changes since v5.0.1.

## Highlights

### Added
- TLS secret type handling (#172)
- Husky pre-commit hook (#166)

### Changed
- Migrated project to ESM with esbuild and vitest (#238)
- Updated Node.js runtime from node20 to node24 (#229)
- Use docker driver in minikube setup (#215)
- Updated CODEOWNERS (#180)
- Numerous npm dependency and GitHub Actions bumps (grouped in CHANGELOG)

### Fixed
- Generic secret type handling (#168)

## Version bumps
- `package.json`: 5.0.0 → 6.0.0
- `package-lock.json`: 5.0.0 → 6.0.0
- `README.md`: `azure/k8s-create-secret@v4`/`@v2` → `@v6`

See `CHANGELOG.md` for the full list.