### PR TITLE
chore: move husky to devDependencies, add version sync pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,3 +5,27 @@ npm run format-check || {
   echo "💡 Run 'npm run format' or 'prettier --write .' to fix formatting issues."
   exit 1
 }
+
+STAGED=$(git diff --cached --name-only)
+if echo "$STAGED" | grep -qE '^(package\.json|package-lock\.json|CHANGELOG\.md)$'; then
+  PKG_VERSION=$(node -p "require('./package.json').version")
+  LOCK_VERSION=$(node -p "require('./package-lock.json').version")
+  CHANGELOG_VERSION=$(sed -n 's/^## \[\([^]]*\)\].*/\1/p' CHANGELOG.md | head -1)
+
+  MISMATCH=""
+  if [ "$PKG_VERSION" != "$LOCK_VERSION" ]; then
+    MISMATCH="${MISMATCH}\n  package.json:      ${PKG_VERSION}\n  package-lock.json: ${LOCK_VERSION}"
+  fi
+  if [ "$PKG_VERSION" != "$CHANGELOG_VERSION" ]; then
+    MISMATCH="${MISMATCH}\n  package.json: ${PKG_VERSION}\n  CHANGELOG.md: ${CHANGELOG_VERSION}"
+  fi
+
+  if [ -n "$MISMATCH" ]; then
+    echo ""
+    echo "Version mismatch detected:"
+    echo -e "$MISMATCH"
+    echo ""
+    echo "Ensure package.json, package-lock.json, and CHANGELOG.md all have the same version."
+    exit 1
+  fi
+fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,21 +12,21 @@
             "@actions/core": "^3.0.0",
             "@actions/exec": "^3.0.0",
             "@actions/tool-cache": "^4.0.0",
-            "@kubernetes/client-node": "^1.4.0",
-            "husky": "^9.1.7"
+            "@kubernetes/client-node": "^1.4.0"
          },
          "devDependencies": {
             "@types/node": "^25.5.2",
             "esbuild": "^0.28.0",
+            "husky": "^9.1.7",
             "prettier": "^3.8.1",
             "typescript": "^6.0.3",
             "vitest": "^4.1.2"
          }
       },
       "node_modules/@actions/core": {
-         "version": "3.0.0",
-         "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.0.tgz",
-         "integrity": "sha512-zYt6cz+ivnTmiT/ksRVriMBOiuoUpDCJJlZ5KPl2/FRdvwU3f7MPh9qftvbkXJThragzUZieit2nyHUyw53Seg==",
+         "version": "3.0.1",
+         "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
+         "integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
          "license": "MIT",
          "dependencies": {
             "@actions/exec": "^3.0.0",
@@ -43,9 +43,9 @@
          }
       },
       "node_modules/@actions/http-client": {
-         "version": "4.0.0",
-         "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.0.tgz",
-         "integrity": "sha512-QuwPsgVMsD6qaPD57GLZi9sqzAZCtiJT8kVBCDpLtxhL5MydQ4gS+DrejtZZPdIYyB1e95uCK9Luyds7ybHI3g==",
+         "version": "4.0.1",
+         "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.1.tgz",
+         "integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
          "license": "MIT",
          "dependencies": {
             "tunnel": "^0.0.6",
@@ -637,9 +637,9 @@
          }
       },
       "node_modules/@oxc-project/types": {
-         "version": "0.124.0",
-         "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
-         "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+         "version": "0.126.0",
+         "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.126.0.tgz",
+         "integrity": "sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==",
          "dev": true,
          "license": "MIT",
          "funding": {
@@ -647,9 +647,9 @@
          }
       },
       "node_modules/@rolldown/binding-android-arm64": {
-         "version": "1.0.0-rc.15",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
-         "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+         "version": "1.0.0-rc.16",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.16.tgz",
+         "integrity": "sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==",
          "cpu": [
             "arm64"
          ],
@@ -664,9 +664,9 @@
          }
       },
       "node_modules/@rolldown/binding-darwin-arm64": {
-         "version": "1.0.0-rc.15",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
-         "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+         "version": "1.0.0-rc.16",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.16.tgz",
+         "integrity": "sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==",
          "cpu": [
             "arm64"
          ],
@@ -681,9 +681,9 @@
          }
       },
       "node_modules/@rolldown/binding-darwin-x64": {
-         "version": "1.0.0-rc.15",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
-         "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+         "version": "1.0.0-rc.16",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.16.tgz",
+         "integrity": "sha512-r/OmdR00HmD4i79Z//xO06uEPOq5hRXdhw7nzkxQxwSavs3PSHa1ijntdpOiZ2mzOQ3fVVu8C1M19FoNM+dMUQ==",
          "cpu": [
             "x64"
          ],
@@ -698,9 +698,9 @@
          }
       },
       "node_modules/@rolldown/binding-freebsd-x64": {
-         "version": "1.0.0-rc.15",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
-         "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+         "version": "1.0.0-rc.16",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.16.tgz",
+         "integrity": "sha512-KcRE5w8h0OnjUatG8pldyD14/CQ5Phs1oxfR+3pKDjboHRo9+MkqQaiIZlZRpsxC15paeXme/I127tUa9TXJ6g==",
          "cpu": [
             "x64"
          ],
@@ -715,9 +715,9 @@
          }
       },
       "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-         "version": "1.0.0-rc.15",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
-         "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+         "version": "1.0.0-rc.16",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.16.tgz",
+         "integrity": "sha512-bT0guA1bpxEJ/ZhTRniQf7rNF8ybvXOuWbNIeLABaV5NGjx4EtOWBTSRGWFU9ZWVkPOZ+HNFP8RMcBokBiZ0Kg==",
          "cpu": [
             "arm"
          ],
@@ -732,9 +732,9 @@
          }
       },
       "node_modules/@rolldown/binding-linux-arm64-gnu": {
-         "version": "1.0.0-rc.15",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
-         "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+         "version": "1.0.0-rc.16",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.16.tgz",
+         "integrity": "sha512-+tHktCHWV8BDQSjemUqm/Jl/TPk3QObCTIjmdDy/nlupcujZghmKK2962LYrqFpWu+ai01AN/REOH3NEpqvYQg==",
          "cpu": [
             "arm64"
          ],
@@ -749,9 +749,9 @@
          }
       },
       "node_modules/@rolldown/binding-linux-arm64-musl": {
-         "version": "1.0.0-rc.15",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
-         "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+         "version": "1.0.0-rc.16",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.16.tgz",
+         "integrity": "sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==",
          "cpu": [
             "arm64"
          ],
@@ -766,9 +766,9 @@
          }
       },
       "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-         "version": "1.0.0-rc.15",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
-         "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+         "version": "1.0.0-rc.16",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.16.tgz",
+         "integrity": "sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==",
          "cpu": [
             "ppc64"
          ],
@@ -783,9 +783,9 @@
          }
       },
       "node_modules/@rolldown/binding-linux-s390x-gnu": {
-         "version": "1.0.0-rc.15",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
-         "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+         "version": "1.0.0-rc.16",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.16.tgz",
+         "integrity": "sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==",
          "cpu": [
             "s390x"
          ],
@@ -800,9 +800,9 @@
          }
       },
       "node_modules/@rolldown/binding-linux-x64-gnu": {
-         "version": "1.0.0-rc.15",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
-         "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+         "version": "1.0.0-rc.16",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.16.tgz",
+         "integrity": "sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==",
          "cpu": [
             "x64"
          ],
@@ -817,9 +817,9 @@
          }
       },
       "node_modules/@rolldown/binding-linux-x64-musl": {
-         "version": "1.0.0-rc.15",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
-         "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+         "version": "1.0.0-rc.16",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.16.tgz",
+         "integrity": "sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==",
          "cpu": [
             "x64"
          ],
@@ -834,9 +834,9 @@
          }
       },
       "node_modules/@rolldown/binding-openharmony-arm64": {
-         "version": "1.0.0-rc.15",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
-         "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+         "version": "1.0.0-rc.16",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.16.tgz",
+         "integrity": "sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==",
          "cpu": [
             "arm64"
          ],
@@ -851,9 +851,9 @@
          }
       },
       "node_modules/@rolldown/binding-wasm32-wasi": {
-         "version": "1.0.0-rc.15",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
-         "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+         "version": "1.0.0-rc.16",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.16.tgz",
+         "integrity": "sha512-3Q2KQxnC8IJOLqXmUMoYwyIPZU9hzRbnHaoV3Euz+VVnjZKcY8ktnNP8T9R4/GGQtb27C/UYKABxesKWb8lsvQ==",
          "cpu": [
             "wasm32"
          ],
@@ -863,16 +863,16 @@
          "dependencies": {
             "@emnapi/core": "1.9.2",
             "@emnapi/runtime": "1.9.2",
-            "@napi-rs/wasm-runtime": "^1.1.3"
+            "@napi-rs/wasm-runtime": "^1.1.4"
          },
          "engines": {
-            "node": ">=14.0.0"
+            "node": "^20.19.0 || >=22.12.0"
          }
       },
       "node_modules/@rolldown/binding-win32-arm64-msvc": {
-         "version": "1.0.0-rc.15",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
-         "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+         "version": "1.0.0-rc.16",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.16.tgz",
+         "integrity": "sha512-tj7XRemQcOcFwv7qhpUxMTBbI5mWMlE4c1Omhg5+h8GuLXzyj8HviYgR+bB2DMDgRqUE+jiDleqSCRjx4aYk/Q==",
          "cpu": [
             "arm64"
          ],
@@ -887,9 +887,9 @@
          }
       },
       "node_modules/@rolldown/binding-win32-x64-msvc": {
-         "version": "1.0.0-rc.15",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
-         "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+         "version": "1.0.0-rc.16",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.16.tgz",
+         "integrity": "sha512-PH5DRZT+F4f2PTXRXR8uJxnBq2po/xFtddyabTJVJs/ZYVHqXPEgNIr35IHTEa6bpa0Q8Awg+ymkTaGnKITw4g==",
          "cpu": [
             "x64"
          ],
@@ -904,9 +904,9 @@
          }
       },
       "node_modules/@rolldown/pluginutils": {
-         "version": "1.0.0-rc.15",
-         "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
-         "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+         "version": "1.0.0-rc.16",
+         "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.16.tgz",
+         "integrity": "sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==",
          "dev": true,
          "license": "MIT"
       },
@@ -988,16 +988,16 @@
          }
       },
       "node_modules/@vitest/expect": {
-         "version": "4.1.4",
-         "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
-         "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+         "version": "4.1.5",
+         "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+         "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
             "@standard-schema/spec": "^1.1.0",
             "@types/chai": "^5.2.2",
-            "@vitest/spy": "4.1.4",
-            "@vitest/utils": "4.1.4",
+            "@vitest/spy": "4.1.5",
+            "@vitest/utils": "4.1.5",
             "chai": "^6.2.2",
             "tinyrainbow": "^3.1.0"
          },
@@ -1006,13 +1006,13 @@
          }
       },
       "node_modules/@vitest/mocker": {
-         "version": "4.1.4",
-         "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
-         "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+         "version": "4.1.5",
+         "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+         "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
-            "@vitest/spy": "4.1.4",
+            "@vitest/spy": "4.1.5",
             "estree-walker": "^3.0.3",
             "magic-string": "^0.30.21"
          },
@@ -1033,9 +1033,9 @@
          }
       },
       "node_modules/@vitest/pretty-format": {
-         "version": "4.1.4",
-         "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
-         "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+         "version": "4.1.5",
+         "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+         "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
@@ -1046,13 +1046,13 @@
          }
       },
       "node_modules/@vitest/runner": {
-         "version": "4.1.4",
-         "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
-         "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+         "version": "4.1.5",
+         "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+         "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
-            "@vitest/utils": "4.1.4",
+            "@vitest/utils": "4.1.5",
             "pathe": "^2.0.3"
          },
          "funding": {
@@ -1060,14 +1060,14 @@
          }
       },
       "node_modules/@vitest/snapshot": {
-         "version": "4.1.4",
-         "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
-         "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+         "version": "4.1.5",
+         "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+         "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
-            "@vitest/pretty-format": "4.1.4",
-            "@vitest/utils": "4.1.4",
+            "@vitest/pretty-format": "4.1.5",
+            "@vitest/utils": "4.1.5",
             "magic-string": "^0.30.21",
             "pathe": "^2.0.3"
          },
@@ -1076,9 +1076,9 @@
          }
       },
       "node_modules/@vitest/spy": {
-         "version": "4.1.4",
-         "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
-         "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+         "version": "4.1.5",
+         "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+         "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
          "dev": true,
          "license": "MIT",
          "funding": {
@@ -1086,13 +1086,13 @@
          }
       },
       "node_modules/@vitest/utils": {
-         "version": "4.1.4",
-         "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
-         "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+         "version": "4.1.5",
+         "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+         "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
-            "@vitest/pretty-format": "4.1.4",
+            "@vitest/pretty-format": "4.1.5",
             "convert-source-map": "^2.0.0",
             "tinyrainbow": "^3.1.0"
          },
@@ -1184,9 +1184,9 @@
          }
       },
       "node_modules/bare-os": {
-         "version": "3.8.7",
-         "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.7.tgz",
-         "integrity": "sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==",
+         "version": "3.9.0",
+         "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.0.tgz",
+         "integrity": "sha512-JTjuZyNIDpw+GytMO4a6TK1VXdVKKJr6DRxEHasyuYyShV2deuiHJK/ahGZlebc+SG0/wJCB9XK8gprBGDFi/Q==",
          "license": "Apache-2.0",
          "engines": {
             "bare": ">=1.14.0"
@@ -1228,9 +1228,9 @@
          }
       },
       "node_modules/bare-url": {
-         "version": "2.4.0",
-         "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz",
-         "integrity": "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==",
+         "version": "2.4.2",
+         "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.2.tgz",
+         "integrity": "sha512-/9a2j4ac6ckpmAHvod/ob7x439OAHst/drc2Clnq+reRYd/ovddwcF4LfoxHyNk5AuGBnPg+HqFjmE/Zpq6v0A==",
          "license": "Apache-2.0",
          "dependencies": {
             "bare-path": "^3.0.0"
@@ -1601,9 +1601,9 @@
          }
       },
       "node_modules/hasown": {
-         "version": "2.0.2",
-         "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-         "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+         "version": "2.0.3",
+         "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+         "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
          "license": "MIT",
          "dependencies": {
             "function-bind": "^1.1.2"
@@ -1625,6 +1625,7 @@
          "version": "9.1.7",
          "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
          "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+         "dev": true,
          "license": "MIT",
          "bin": {
             "husky": "bin.js"
@@ -2179,14 +2180,14 @@
          "license": "MIT"
       },
       "node_modules/rolldown": {
-         "version": "1.0.0-rc.15",
-         "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
-         "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+         "version": "1.0.0-rc.16",
+         "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.16.tgz",
+         "integrity": "sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
-            "@oxc-project/types": "=0.124.0",
-            "@rolldown/pluginutils": "1.0.0-rc.15"
+            "@oxc-project/types": "=0.126.0",
+            "@rolldown/pluginutils": "1.0.0-rc.16"
          },
          "bin": {
             "rolldown": "bin/cli.mjs"
@@ -2195,21 +2196,21 @@
             "node": "^20.19.0 || >=22.12.0"
          },
          "optionalDependencies": {
-            "@rolldown/binding-android-arm64": "1.0.0-rc.15",
-            "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
-            "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
-            "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
-            "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
-            "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
-            "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
-            "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
-            "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
-            "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
-            "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
-            "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
-            "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
-            "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
-            "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+            "@rolldown/binding-android-arm64": "1.0.0-rc.16",
+            "@rolldown/binding-darwin-arm64": "1.0.0-rc.16",
+            "@rolldown/binding-darwin-x64": "1.0.0-rc.16",
+            "@rolldown/binding-freebsd-x64": "1.0.0-rc.16",
+            "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.16",
+            "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.16",
+            "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.16",
+            "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.16",
+            "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.16",
+            "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.16",
+            "@rolldown/binding-linux-x64-musl": "1.0.0-rc.16",
+            "@rolldown/binding-openharmony-arm64": "1.0.0-rc.16",
+            "@rolldown/binding-wasm32-wasi": "1.0.0-rc.16",
+            "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.16",
+            "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.16"
          }
       },
       "node_modules/semver": {
@@ -2454,17 +2455,17 @@
          "license": "MIT"
       },
       "node_modules/vite": {
-         "version": "8.0.8",
-         "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
-         "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+         "version": "8.0.9",
+         "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.9.tgz",
+         "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
             "lightningcss": "^1.32.0",
             "picomatch": "^4.0.4",
-            "postcss": "^8.5.8",
-            "rolldown": "1.0.0-rc.15",
-            "tinyglobby": "^0.2.15"
+            "postcss": "^8.5.10",
+            "rolldown": "1.0.0-rc.16",
+            "tinyglobby": "^0.2.16"
          },
          "bin": {
             "vite": "bin/vite.js"
@@ -2532,19 +2533,19 @@
          }
       },
       "node_modules/vitest": {
-         "version": "4.1.4",
-         "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
-         "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+         "version": "4.1.5",
+         "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+         "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
-            "@vitest/expect": "4.1.4",
-            "@vitest/mocker": "4.1.4",
-            "@vitest/pretty-format": "4.1.4",
-            "@vitest/runner": "4.1.4",
-            "@vitest/snapshot": "4.1.4",
-            "@vitest/spy": "4.1.4",
-            "@vitest/utils": "4.1.4",
+            "@vitest/expect": "4.1.5",
+            "@vitest/mocker": "4.1.5",
+            "@vitest/pretty-format": "4.1.5",
+            "@vitest/runner": "4.1.5",
+            "@vitest/snapshot": "4.1.5",
+            "@vitest/spy": "4.1.5",
+            "@vitest/utils": "4.1.5",
             "es-module-lexer": "^2.0.0",
             "expect-type": "^1.3.0",
             "magic-string": "^0.30.21",
@@ -2572,12 +2573,12 @@
             "@edge-runtime/vm": "*",
             "@opentelemetry/api": "^1.9.0",
             "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-            "@vitest/browser-playwright": "4.1.4",
-            "@vitest/browser-preview": "4.1.4",
-            "@vitest/browser-webdriverio": "4.1.4",
-            "@vitest/coverage-istanbul": "4.1.4",
-            "@vitest/coverage-v8": "4.1.4",
-            "@vitest/ui": "4.1.4",
+            "@vitest/browser-playwright": "4.1.5",
+            "@vitest/browser-preview": "4.1.5",
+            "@vitest/browser-webdriverio": "4.1.5",
+            "@vitest/coverage-istanbul": "4.1.5",
+            "@vitest/coverage-v8": "4.1.5",
+            "@vitest/ui": "4.1.5",
             "happy-dom": "*",
             "jsdom": "*",
             "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
       "@actions/core": "^3.0.0",
       "@actions/exec": "^3.0.0",
       "@actions/tool-cache": "^4.0.0",
-      "@kubernetes/client-node": "^1.4.0",
-      "husky": "^9.1.7"
+      "@kubernetes/client-node": "^1.4.0"
    },
    "devDependencies": {
       "@types/node": "^25.5.2",
       "esbuild": "^0.28.0",
+      "husky": "^9.1.7",
       "prettier": "^3.8.1",
       "typescript": "^6.0.3",
       "vitest": "^4.1.2"


### PR DESCRIPTION
## Summary

- Move `husky` from `dependencies` to `devDependencies` — it's a dev tool and shouldn't be bundled
- Add version sync check to `.husky/pre-commit` — validates that `package.json`, `package-lock.json`, and `CHANGELOG.md` versions match before committing

Both are post-release cleanup items from the v6.0.0 migration review.