### PR TITLE
Release v6.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [6.0.1] - 2026-06-22
+
+### Changed
+
+- [#243](https://github.com/Azure/k8s-create-secret/pull/243) Move husky to devDependencies, add version sync pre-commit hook
+- [#254](https://github.com/Azure/k8s-create-secret/pull/254) Remove deprecated OliverMKing release workflow, pin actions to SHA
+- Bump npm dependencies: `ip-address`, `@types/node`, `ws`, `vitest`, `esbuild`, `js-yaml`, `form-data`, `undici`, `typescript` (#241, #244, #246, #247, #250, #251, #252, #255, #258, #260, #261, #262, #263, #264, #265)
+- Bump GitHub Actions: `github/codeql-action` and other grouped action updates in `.github/workflows` (#242, #245, #248, #249, #253, #256, #259)
+
+### Fixed
+
+- [#257](https://github.com/Azure/k8s-create-secret/pull/257) Stop logging full API responses and error objects to workflow logs
+
 ## [6.0.0] - 2026-04-20
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
    "name": "k8s-create-secret-action",
-   "version": "6.0.0",
+   "version": "6.0.1",
    "lockfileVersion": 3,
    "requires": true,
    "packages": {
       "": {
          "name": "k8s-create-secret-action",
-         "version": "6.0.0",
+         "version": "6.0.1",
          "license": "MIT",
          "dependencies": {
             "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "k8s-create-secret-action",
-   "version": "6.0.0",
+   "version": "6.0.1",
    "private": true,
    "type": "module",
    "main": "lib/index.js",


### PR DESCRIPTION
## Summary

Release PR for **v6.0.1** — patch version bump covering all changes since v6.0.0.

## Highlights

### Changed
- Move husky to devDependencies, add version sync pre-commit hook (#243)
- Remove deprecated OliverMKing release workflow, pin actions to SHA (#254)
- Numerous npm dependency and GitHub Actions bumps (grouped in CHANGELOG)

### Fixed
- Stop logging full API responses and error objects to workflow logs (#257)

## Version bumps
- `package.json`: 6.0.0 → 6.0.1
- `package-lock.json`: 6.0.0 → 6.0.1

See `CHANGELOG.md` for the full list.