### PR TITLE
fix(run): skip 404 warning when secret does not exist

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -220,21 +220,26 @@ export async function run() {
    const namespace: string = core.getInput('namespace') || 'default'
 
    // Delete if exists
-   let deleteSecretResponse
    try {
-      let deleteRequest: CoreV1ApiDeleteNamespacedSecretRequest = {
+      const deleteRequest: CoreV1ApiDeleteNamespacedSecretRequest = {
          name: secretName,
          namespace: namespace
       }
-      deleteSecretResponse = await api.deleteNamespacedSecret(deleteRequest)
+      await api.deleteNamespacedSecret(deleteRequest)
    } catch (err: any) {
-      core.warning(
-         `Failed to delete secret with statusCode: ${err.response?.statusCode}`
-      )
-      core.warning(err.response?.body?.metadata)
+      if (err.response?.statusCode === 404) {
+         core.debug(`Secret ${secretName} does not exist, creating new secret`)
+      } else {
+         const statusCode = err.response?.statusCode
+         const detail =
+            err.response?.body?.message ?? err.message ?? String(err)
+         core.warning(
+            statusCode !== undefined
+               ? `Failed to delete secret with statusCode ${statusCode}: ${detail}`
+               : `Failed to delete secret: ${detail}`
+         )
+      }
    }
-   core.info('Deleting secret:')
-   core.debug('Delete secret response received')
 
    const secret = await buildSecret(secretName, namespace, secretType)
    core.info('Creating secret')


### PR DESCRIPTION
This PR fixes #93 and #97. Because the action always tries to delete a secret before creating it, first-time runs failed the delete with a 404 and emitted a scary yellow Failed to delete secret with statusCode: 404 warning followed by Warning: {} and a trailing [Deleting secret:](vscode-file://vscode-app/c:/Users/t-bebamisile/AppData/Local/Programs/Microsoft%20VS%20Code/7a8049eb2d/resources/app/out/vs/code/electron-browser/workbench/workbench.html) / undefined on every fresh secret, even though nothing was actually wrong (#93). And when the delete genuinely failed, the warning printed the wrong field (an always-empty metadata object) and lost all context whenever the Kubernetes client rejected with a plain Error instead of an HTTP error (#97). Now the 404 is treated as expected and stays quiet, real failures surface the actual error message from either shape, and the misplaced trailing log lines are gone.