### PR TITLE
chore: enforce 7-day dependency freshness period + signed commit check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,16 +3,28 @@ updates:
    - package-ecosystem: npm
      directory: /
      schedule:
-        interval: weekly
+        interval: cron
+        cronjob: '0 8 1,15 * *'
+     cooldown:
+        default-days: 7
      groups:
-        actions:
+        minor-and-patch:
            patterns:
               - '*'
+           update-types:
+              - minor
+              - patch
    - package-ecosystem: github-actions
      directory: .github/workflows
      schedule:
-        interval: weekly
+        interval: cron
+        cronjob: '0 8 1,15 * *'
+     cooldown:
+        default-days: 7
      groups:
-        actions:
+        minor-and-patch:
            patterns:
               - '*'
+           update-types:
+              - minor
+              - patch

--- a/.github/workflows/check-signed-commits.yml
+++ b/.github/workflows/check-signed-commits.yml
@@ -1,0 +1,12 @@
+name: Check Signed Commits
+
+on:
+   pull_request:
+
+permissions:
+   contents: read
+   pull-requests: write
+
+jobs:
+   signed:
+      uses: Azure/action-release-workflows/.github/workflows/check_signed_commits.yaml@2ff084415c5af591fd13d95ddbfc4cdb5ed2012e

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/README.md
+++ b/README.md
@@ -89,6 +89,27 @@ Unit tests are run with [Vitest](https://vitest.dev/) and can be found in the `.
 
 Integration tests use [Minikube](https://minikube.sigs.k8s.io/docs/) and are executed within workflows in `./github/workflows`
 
+# Dependencies
+
+This repository enforces a **7-day dependency freshness ("bake") period**: newly
+published npm packages are not adopted until they have been available for at
+least 7 days, giving the ecosystem time to catch broken or malicious releases.
+
+- **Dependabot** uses a 7-day `cooldown` and opens PRs on the 1st and 15th of
+  each month, grouping minor/patch updates into a single PR. Major updates are
+  still raised individually so they get their own review.
+- **`.npmrc`** sets `min-release-age=7` (days), which applies the same rule to
+  local `npm install`. This requires npm >= 11.10.0; the version bundled with
+  Node 24 (this action's runtime) satisfies that. On older npm the setting is
+  ignored, so Dependabot's `cooldown` remains the authoritative control.
+
+**Security exception:** to adopt an urgent patch that is less than 7 days old,
+install it once with the age check disabled:
+
+```sh
+npm install <pkg> --min-release-age=0
+```
+
 # Contributing
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a


### PR DESCRIPTION
Brings k8s-create-secret in line with the dependency-freshness standardization already merged in aks-set-context #258, k8s-lint #228 and k8s-bake #295 (and proposed in k8s-set-context #277). Today this repo has **no** cooldown — dependabot runs `weekly` with a single group matching `*`.

### Dependency freshness

| | before | after |
|---|---|---|
| dependabot `cooldown` | none | `default-days: 7` |
| schedule | `weekly` | cron `0 8 1,15 * *` |
| grouping | one `*` group (majors lumped in) | `minor-and-patch` group; majors raised individually |
| local installs | unconstrained | `.npmrc` `min-release-age=7` |

**Deliberately omitted:** the `engines.npm >= 11.10.0` + `engine-strict` guard that aks-set-context and k8s-lint carry. Node 24 — this action's runtime (`runs.using: node24`) — bundles npm 11.17, so the gate only ever fires for a contributor already off the target runtime, at the cost of hard-failing their `npm install`. Dependabot's `cooldown` enforces the bake server-side regardless of local npm. This matches the two most recent repos.

### Signed commit check

Adds `check-signed-commits.yml` calling the shared `check_signed_commits.yaml` reusable workflow, pinned to `2ff0844` (the same action-release-workflows SHA `release-pr.yml` already uses) rather than `@main`, since it runs with write access to PR comments. The caller declares `contents: read` / `pull-requests: write` explicitly rather than depending on the repo's default token permissions.

### Overlap check

No conflict with the 6 open dependabot PRs (#276–#281) — those touch `package.json`/`package-lock.json` and `codeql.yml`/`defaultLabels.yml`/`release-pr.yml`. This PR touches none of those files. Note those 6 were all opened *before* any cooldown existed, so they are not covered by the bake period; merging this does not retroactively vet them.

Verified: build, 12/12 tests, prettier all pass. Lockfile untouched (204/204 sha512, registry.npmjs.org only).